### PR TITLE
Add negative JWT verification test

### DIFF
--- a/apps/api/__tests__/lib/jwt.test.ts
+++ b/apps/api/__tests__/lib/jwt.test.ts
@@ -21,4 +21,18 @@ describe('jwt utils', () => {
     expect(decoded.email).toBe(payload.email);
     expect(decoded.sub).toBe(payload.sub);
   });
+
+  it('should throw when verifying an invalid token', () => {
+    const accessToken = signAccessToken(payload);
+    const tamperedAccess = accessToken.slice(0, -1) +
+      (accessToken.slice(-1) === 'a' ? 'b' : 'a');
+    expect(() => verifyAccessToken(tamperedAccess)).toThrow();
+    expect(() => verifyAccessToken('invalid.token')).toThrow();
+
+    const refreshToken = signRefreshToken(payload);
+    const tamperedRefresh = refreshToken.slice(0, -1) +
+      (refreshToken.slice(-1) === 'a' ? 'b' : 'a');
+    expect(() => verifyRefreshToken(tamperedRefresh)).toThrow();
+    expect(() => verifyRefreshToken('invalid.token')).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- extend JWT tests to ensure verify functions throw errors on invalid tokens

## Testing
- `pnpm --filter api test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.0.tgz)*
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
