### PR TITLE
Fix API server port

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import authRoutes from './routes/auth';
 // ­–––– DEBUG: afișează toate rutele încărcate ––––
 import listEndpoints from 'express-list-endpoints';
+import { env } from './env';
 
 const app = express();
 
@@ -11,4 +12,7 @@ app.use(express.json());
 // 🟢 rute API
 app.use('/api/v1/auth', authRoutes);
 
-app.listen(3000, () => console.log('Server running on http://localhost:3000'));
+const port = Number(env.PORT);
+app.listen(port, () =>
+  console.log(`Server running on http://localhost:${port}`),
+);


### PR DESCRIPTION
## Summary
- ensure the API server reads the `PORT` environment variable instead of using a hard-coded port

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ae3fa918832e889e4882a86b829c