### PR TITLE
Add status route and fix commit message hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx.cmd --no -- commitlint --edit "$1"
+npx --no -- commitlint --edit "$1"

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import authRoutes from './routes/auth';
+import statusRoutes from './routes/status';
 // ­–––– DEBUG: afișează toate rutele încărcate ––––
 import listEndpoints from 'express-list-endpoints';
 import { env } from './env';
@@ -11,6 +12,7 @@ app.use(express.json());
 
 // 🟢 rute API
 app.use('/api/v1/auth', authRoutes);
+app.use('/api/v1/status', statusRoutes);
 
 const port = Number(env.PORT);
 app.listen(port, () =>

--- a/apps/api/src/routes/status.ts
+++ b/apps/api/src/routes/status.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add a `/api/v1/status` endpoint for health checks
- fix commit message Husky hook to use `npx` on all platforms

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Can't reach database server)*
