### PR TITLE
Add Redis-based rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ DATABASE_URL=postgresql://postgres:postgres@db:5432/site_db
 
 # 🧠 Logging (Logtail or other providers)
 LOGTAIL_TOKEN=dummy
+
+# Cache
+REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Un site premium pentru un restaurant modern. Monorepo full-stack cu pnpm, Docker
 ## Configurare API
 
 Inainte de a porni API-ul sau scripturile de seed, copiaza `apps/api/.env.example` in `apps/api/.env` si actualizeaza valorile variabilelor.
+
+API-ul limiteaza fiecare IP la 100 de cereri in 10 minute. Daca depasesti limita vei primi raspuns **429 Too Many Requests**.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -11,3 +11,6 @@ JWT_REFRESH_SECRET=your_refresh_secret
 
 # Logging
 LOGTAIL_TOKEN=your-logtail-token
+
+# Cache
+REDIS_URL=redis://localhost:6379

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.ts",
   "scripts": {
     "db:push:test": "pnpm exec cross-env DOTENV_CONFIG_PATH=.env.test prisma db push --force-reset --schema=prisma/schema.prisma",
-    "seed:test":    "pnpm exec cross-env DOTENV_CONFIG_PATH=.env.test ts-node prisma/seed.ts",
-    "test":         "pnpm exec cross-env DOTENV_CONFIG_PATH=.env.test jest --coverage",
-    "test:watch":   "pnpm exec cross-env DOTENV_CONFIG_PATH=.env.test jest --watch",
+    "seed:test": "pnpm exec cross-env DOTENV_CONFIG_PATH=.env.test ts-node prisma/seed.ts",
+    "test": "pnpm exec cross-env DOTENV_CONFIG_PATH=.env.test jest --coverage",
+    "test:watch": "pnpm exec cross-env DOTENV_CONFIG_PATH=.env.test jest --watch",
     "studio:test": "powershell -Command \"$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/site_test_db'; npx prisma studio\"",
     "db:reset:test": "dotenv -e .env.test -- prisma migrate reset --force --skip-seed",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
@@ -30,6 +30,8 @@
     "envalid": "^8.0.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
+    "rate-limiter-flexible": "^7.1.1",
+    "redis": "^5.5.6",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.17.0"
   },

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -7,6 +7,7 @@ interface EnvSchema {
   JWT_ACCESS_SECRET: string;
   JWT_REFRESH_SECRET: string;
   LOGTAIL_TOKEN: string;
+  REDIS_URL: string;
 }
 
 export const env = envSchema<EnvSchema>({
@@ -27,6 +28,7 @@ export const env = envSchema<EnvSchema>({
       JWT_ACCESS_SECRET: { type: 'string' },
       JWT_REFRESH_SECRET: { type: 'string' },
       LOGTAIL_TOKEN: { type: 'string', default: '' }, // fallback OK
+      REDIS_URL: { type: 'string', default: 'redis://localhost:6379' },
     },
   },
   dotenv: true,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,11 +7,13 @@ import listEndpoints from 'express-list-endpoints';
 import { env } from './env';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './utils/swagger';
+import { rateLimiter } from './middlewares/rateLimiter';
 
 const app = express();
 
 // 🟢 trebuie să fie primul!
 app.use(express.json());
+app.use(rateLimiter);
 
 // 🟢 rute API
 app.use('/api/v1/auth', authRoutes);

--- a/apps/api/src/lib/redis.ts
+++ b/apps/api/src/lib/redis.ts
@@ -1,0 +1,13 @@
+import { createClient } from 'redis';
+
+const url = process.env.REDIS_URL || 'redis://localhost:6379';
+
+export const redis = createClient({ url });
+
+redis.on('error', (err) => {
+  console.error('[redis] connection error', err);
+});
+
+redis.connect().catch((err) => {
+  console.error('[redis] connect failed', err);
+});

--- a/apps/api/src/middlewares/rateLimiter.ts
+++ b/apps/api/src/middlewares/rateLimiter.ts
@@ -1,0 +1,25 @@
+// apps/api/src/middlewares/rateLimiter.ts
+import { Request, Response, NextFunction } from 'express';
+import { RateLimiterRedis } from 'rate-limiter-flexible';
+import { redis } from '../lib/redis';
+
+const rateLimiter = new RateLimiterRedis({
+  storeClient: redis,
+  points: 100,
+  duration: 600,
+});
+
+export const rateLimiterMiddleware = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    await rateLimiter.consume(req.ip);
+    next();
+  } catch {
+    res.status(429).json({ message: 'Too Many Requests' });
+  }
+};
+
+export { rateLimiterMiddleware as rateLimiter };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       - '5555:5555'
     env_file:
       - .env
+    environment:
+      - REDIS_URL=redis://redis:6379
     depends_on:
       db:
         condition: service_healthy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,12 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      rate-limiter-flexible:
+        specifier: ^7.1.1
+        version: 7.1.1
+      redis:
+        specifier: ^5.5.6
+        version: 5.5.6
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@5.1.0)
@@ -645,6 +651,34 @@ packages:
   '@prisma/get-platform@6.8.2':
     resolution: {integrity: sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==}
 
+  '@redis/bloom@5.5.6':
+    resolution: {integrity: sha512-bNR3mxkwtfuCxNOzfV8B3R5zA1LiN57EH6zK4jVBIgzMzliNuReZXBFGnXvsi80/SYohajn78YdpYI+XNpqL+A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.5.6
+
+  '@redis/client@5.5.6':
+    resolution: {integrity: sha512-M3Svdwt6oSfyfQdqEr0L2HOJH2vK7GgCFx1NfAQvpWAT4+ljoT1L5S5cKT3dA9NJrxrOPDkdoTPWJnIrGCOcmw==}
+    engines: {node: '>= 18'}
+
+  '@redis/json@5.5.6':
+    resolution: {integrity: sha512-AIsoe3SsGQagqAmSQHaqxEinm5oCWr7zxPWL90kKaEdLJ+zw8KBznf2i9oK0WUFP5pFssSQUXqnscQKe2amfDQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.5.6
+
+  '@redis/search@5.5.6':
+    resolution: {integrity: sha512-JSqasYqO0mVcHL7oxvbySRBBZYRYhFl3W7f0Da7BW8M/r0Z9wCiVrdjnN4/mKBpWZkoJT/iuisLUdPGhpKxBew==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.5.6
+
+  '@redis/time-series@5.5.6':
+    resolution: {integrity: sha512-jkpcgq3NOI3TX7xEAJ3JgesJTxAx7k0m6lNxNsYdEM8KOl+xj7GaB/0CbLkoricZDmFSEAz7ClA1iK9XkGHf+Q==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.5.6
+
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
@@ -1097,6 +1131,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -2659,6 +2697,9 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
+  rate-limiter-flexible@7.1.1:
+    resolution: {integrity: sha512-lsYRcqRSJrKBNt6pMzBJTiCJP5KnwsGWdObMZxd19JFUJRntM+yuHs4/2bs6NZweSLgpsDcykvzyQaumoslWQg==}
+
   raw-body@3.0.0:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
@@ -2679,6 +2720,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  redis@5.5.6:
+    resolution: {integrity: sha512-hbpqBfcuhWHOS9YLNcXcJ4akNr7HFX61Dq3JuFZ9S7uU7C7kvnzuH2PDIXOP62A3eevvACoG8UacuXP3N07xdg==}
+    engines: {node: '>= 18'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3928,6 +3973,26 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.8.2
 
+  '@redis/bloom@5.5.6(@redis/client@5.5.6)':
+    dependencies:
+      '@redis/client': 5.5.6
+
+  '@redis/client@5.5.6':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@5.5.6(@redis/client@5.5.6)':
+    dependencies:
+      '@redis/client': 5.5.6
+
+  '@redis/search@5.5.6(@redis/client@5.5.6)':
+    dependencies:
+      '@redis/client': 5.5.6
+
+  '@redis/time-series@5.5.6(@redis/client@5.5.6)':
+    dependencies:
+      '@redis/client': 5.5.6
+
   '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.27.8': {}
@@ -4487,6 +4552,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cluster-key-slot@1.1.2: {}
 
   co@4.6.0: {}
 
@@ -6311,6 +6378,8 @@ snapshots:
 
   range-parser@1.2.1: {}
 
+  rate-limiter-flexible@7.1.1: {}
+
   raw-body@3.0.0:
     dependencies:
       bytes: 3.1.2
@@ -6335,6 +6404,14 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  redis@5.5.6:
+    dependencies:
+      '@redis/bloom': 5.5.6(@redis/client@5.5.6)
+      '@redis/client': 5.5.6
+      '@redis/json': 5.5.6(@redis/client@5.5.6)
+      '@redis/search': 5.5.6(@redis/client@5.5.6)
+      '@redis/time-series': 5.5.6(@redis/client@5.5.6)
 
   reflect.getprototypeof@1.0.10:
     dependencies:


### PR DESCRIPTION
## Summary
- add `redis` and `rate-limiter-flexible` packages
- create Redis client helper and rate limiter middleware
- register middleware in express app
- expose `REDIS_URL` in environment examples and docker-compose
- document new rate limit behaviour

## Testing
- `pnpm lint`
- `pnpm --filter ./apps/api test` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_6845b1af4a1c832eb2e6f2cf1fab3b8a